### PR TITLE
Create New Defualt Users Playlist

### DIFF
--- a/lib/globals/globalAccessToken.js
+++ b/lib/globals/globalAccessToken.js
@@ -1,0 +1,10 @@
+
+let accessToken = null;
+
+export const setGlobalToken = (newToken) => {
+    accessToken = newToken;
+}
+
+export const getGlobalToken = () => {
+    return accessToken;
+}

--- a/lib/spotify/getAcessToken.js
+++ b/lib/spotify/getAcessToken.js
@@ -1,9 +1,15 @@
+import { getGlobalToken, setGlobalToken } from "../globals/globalAccessToken";
 const client_id = process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_ID;
 const client_secret = process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_SECRET;
 const basic = Buffer.from(`${client_id}:${client_secret}`).toString('base64');
 const TOKEN_ENDPOINT = `https://accounts.spotify.com/api/token`;
 
 export const getAccessToken = async (refresh_token) => {
+    const globalToken = getGlobalToken();
+    if (globalToken) {
+        console.log('Theres all ready a token');
+        return globalToken;
+    }
     const response = await fetch(TOKEN_ENDPOINT, {
         method: 'POST',
         headers: {
@@ -18,5 +24,8 @@ export const getAccessToken = async (refresh_token) => {
         }),
     });
 
-    return response.json();
+    const { access_token } = await response.json();
+    setGlobalToken(access_token);
+
+    return getGlobalToken();
 };

--- a/lib/spotify/getUserId.js
+++ b/lib/spotify/getUserId.js
@@ -1,7 +1,7 @@
 import { getAccessToken } from "../../lib/spotify/getAcessToken"
 
 const getUserId = async (refresh_token) => {
-    const { access_token } = await getAccessToken(refresh_token);
+    const access_token = await getAccessToken(refresh_token);
     const response = await fetch('https://api.spotify.com/v1/me', {
         headers: {
             Authorization: `Bearer ${access_token}`,
@@ -9,7 +9,7 @@ const getUserId = async (refresh_token) => {
     });
     const user = await response.json();
 
-    return { id: user.id, access_token};
+    return user.id;
 };
 
 export default getUserId;

--- a/lib/spotify/getUserId.js
+++ b/lib/spotify/getUserId.js
@@ -1,0 +1,15 @@
+import { getAccessToken } from "../../lib/spotify/getAcessToken"
+
+const getUserId = async (refresh_token) => {
+    const { access_token } = await getAccessToken(refresh_token);
+    const response = await fetch('https://api.spotify.com/v1/me', {
+        headers: {
+            Authorization: `Bearer ${access_token}`,
+        }
+    });
+    const user = await response.json();
+
+    return { id: user.id, access_token};
+};
+
+export default getUserId;

--- a/lib/spotify/getUsersPlaylists.js
+++ b/lib/spotify/getUsersPlaylists.js
@@ -3,7 +3,7 @@ import { getAccessToken } from "./getAcessToken";
 const PLAYLISTS_ENDPOINT = 'https://api.spotify.com/v1/me/playlists';
 
 export const getUsersPlaylists = async (refresh_token) => {
-  const { access_token } = await getAccessToken(refresh_token);
+  const access_token = await getAccessToken(refresh_token);
   return fetch(PLAYLISTS_ENDPOINT, {
     headers: {
       Authorization: `Bearer ${access_token}`,

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -4,8 +4,7 @@ import SpotifyProvider from 'next-auth/providers/spotify';
 export default NextAuth({
   providers: [
     SpotifyProvider({
-      authorization:
-        'https://accounts.spotify.com/authorize?scope=user-read-email,playlist-read-private',
+      authorization: 'https://accounts.spotify.com/authorize?scope=user-read-email,playlist-read-private,playlist-modify-private,playlist-modify-public',
       clientId: process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_ID,
       clientSecret: process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_SECRET,
     }),

--- a/pages/api/createNewDefaultPlaylist.js
+++ b/pages/api/createNewDefaultPlaylist.js
@@ -1,11 +1,13 @@
-import { getAccessToken } from "../../lib/spotify/getAcessToken";
+import { getAccessToken } from '../../lib/spotify/getAcessToken';
 import getUserId from '../../lib/spotify/getUserId';
 import { getSession } from "next-auth/react";
+
 
 const createNewPlaylist = async (req, res) => {
     const session = await getSession({ req });
     const refresh_token = session.token.accessToken;
-    const { id, access_token } = await getUserId(refresh_token);
+    const id = await getUserId(refresh_token);
+    const access_token = await getAccessToken(refresh_token);
     const response = await fetch(`https://api.spotify.com/v1/users/${id}/playlists`, {
         method: 'POST',
         headers: {
@@ -20,29 +22,8 @@ const createNewPlaylist = async (req, res) => {
         })
     })
     const data = await response.json();
-    console.log(data);
 
     return res.status(200).json(data);
 }
-
-
-
-// exports.createPlaylist = function(name, token) {
-//     return axios({
-//         method: 'POST',
-//         url: `https://api.spotify.com/v1/me/playlists`,
-//         data: {
-//             "name": name,
-//             "description": "Playlist generated using singlespotify by Kabir Virji",
-//             "public": true
-//         },
-//         headers: { 
-//             'Accept': 'application/json',
-//             'Content-Type': 'application/json',
-//             'Authorization': `Bearer ${token}`,
-//         }})
-//         .then(res => res.data)
-// }
-
 
 export default createNewPlaylist;

--- a/pages/api/createNewPlaylist.js
+++ b/pages/api/createNewPlaylist.js
@@ -1,0 +1,48 @@
+import { getAccessToken } from "../../lib/spotify/getAcessToken";
+import getUserId from '../../lib/spotify/getUserId';
+import { getSession } from "next-auth/react";
+
+const createNewPlaylist = async (req, res) => {
+    const session = await getSession({ req });
+    const refresh_token = session.token.accessToken;
+    const { id, access_token } = await getUserId(refresh_token);
+    const response = await fetch(`https://api.spotify.com/v1/users/${id}/playlists`, {
+        method: 'POST',
+        headers: {
+            Authorization: `Bearer ${access_token}`,
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+        },
+        body: JSON.stringify({
+            "name": "New Playlist Spotify API",
+            "description": "New playlist description",
+            "public": false
+        })
+    })
+    const data = await response.json();
+    console.log(data);
+
+    return res.status(200).json(data);
+}
+
+
+
+// exports.createPlaylist = function(name, token) {
+//     return axios({
+//         method: 'POST',
+//         url: `https://api.spotify.com/v1/me/playlists`,
+//         data: {
+//             "name": name,
+//             "description": "Playlist generated using singlespotify by Kabir Virji",
+//             "public": true
+//         },
+//         headers: { 
+//             'Accept': 'application/json',
+//             'Content-Type': 'application/json',
+//             'Authorization': `Bearer ${token}`,
+//         }})
+//         .then(res => res.data)
+// }
+
+
+export default createNewPlaylist;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,16 +1,20 @@
 'use client'
-import {useSession, signIn, signOut} from 'next-auth/react';
+import { useSession, signIn, signOut } from 'next-auth/react';
 import { useState } from 'react';
 
 export default function Home() {
-  const {data: session} = useSession();
+  const { data: session } = useSession();
   const [playlists, setPlaylists] = useState([]);
 
-  const getUsersPlaylists = async () =>{ 
-    const response = await fetch('api/playlists')
-    const {items} = await response.json();
-    console.log(items);
-    setPlaylists(items)
+  const getUsersPlaylists = async () => {
+    try {
+      const response = await fetch('api/playlists')
+      const { items } = await response.json();
+      console.log(items);
+      setPlaylists(items)
+    } catch (e) {
+      console.log(e);
+    }
   }
 
   if (session) {
@@ -18,7 +22,7 @@ export default function Home() {
       <>
         Signed in as {session?.token?.name} <br />
         <button onClick={() => signOut()}>Sign out</button>
-        <button onClick={()=> getUsersPlaylists()}>get playlists</button>
+        <button onClick={() => getUsersPlaylists()}>get playlists</button>
         {playlists.map((item) => (
           <div key={item.id}>
             <h1>{item.name}</h1>


### PR DESCRIPTION
The `/api/createNewDefaultPlaylist` API endpoint is created
This endpoint creates a new Playlist in the user's account with default information. The playlist is filled with no songs, a name **New Playlist Spotify API**, and a default description. 
It returns a JSON response with the whole Information of the new Playlist created 

![image](https://github.com/Matdweb/Spotiy-Playlist-Retriever-v12/assets/110640534/dbfa72b6-a814-4af7-9bae-ddd9e0ad69a7)
