### PR TITLE
Add items to playlists

### DIFF
--- a/pages/api/addItemsToPlaylists.js
+++ b/pages/api/addItemsToPlaylists.js
@@ -1,0 +1,32 @@
+import { getAccessToken } from '../../lib/spotify/getAcessToken';
+import { getSession } from "next-auth/react";
+import createNewDefaultPlaylist from './createNewDefaultPlaylist';
+
+
+const addItemsToPlaylists = async (req, res) => {
+    const response = await createNewDefaultPlaylist(req,res);
+    const data = await JSON.parse(response);
+    const playlist_id = data.id;
+    
+    const session = await getSession({ req });
+    const refresh_token = session.token.accessToken;
+    const access_token = await getAccessToken(refresh_token);
+
+    const add = await fetch(`https://api.spotify.com/v1/playlists/${playlist_id}/tracks`,{
+        method: 'POST',
+        headers: {
+            Authorization: `Bearer ${access_token}`,
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+            "uris": ["spotify:track:1HNkqx9Ahdgi1Ixy2xkKkL"],
+            "position": 0
+        })
+    })
+
+    const addItem = await add.json();
+
+    return res.status(200).json(addItem);
+}
+
+export default addItemsToPlaylists;

--- a/pages/api/createNewDefaultPlaylist.js
+++ b/pages/api/createNewDefaultPlaylist.js
@@ -3,7 +3,7 @@ import getUserId from '../../lib/spotify/getUserId';
 import { getSession } from "next-auth/react";
 
 
-const createNewPlaylist = async (req, res) => {
+const createNewDefaultPlaylist = async (req, res) => {
     const session = await getSession({ req });
     const refresh_token = session.token.accessToken;
     const id = await getUserId(refresh_token);
@@ -23,7 +23,7 @@ const createNewPlaylist = async (req, res) => {
     })
     const data = await response.json();
 
-    return res.status(200).json(data);
+    return JSON.stringify(data);
 }
 
-export default createNewPlaylist;
+export default createNewDefaultPlaylist;


### PR DESCRIPTION
The `/api/addItemsToPlaylists` API endpoint is created
This endpoint creates a new Default Playlist with the help of a call to the now function `createNewDefaultPlaylist()` and with the ID of the new Playlist, it adds a song. This works with the song's URI `spotify:track:1HNkqx9Ahdgi1Ixy2xkKkL` which is Ed Sheeran's song _Photograph_. This URI is attached to the request's body and sent to the Default Playlist.

`body: JSON.stringify({
   "uris": ["spotify:track:1HNkqx9Ahdgi1Ixy2xkKkL"], 
   "position": 0
 })`

Then the endpoint returns a JSON with the "snapshot_id"
![image](https://github.com/Matdweb/Spotiy-Playlist-Retriever-v12/assets/110640534/79d59d7a-70e3-4301-a355-d2ab5f1ea03c)

This way the application is able to add this song to the new Playlist in a user account
